### PR TITLE
Update patch and checksums for recent build

### DIFF
--- a/Oberon/OberonFromScratch.Tool.txt
+++ b/Oberon/OberonFromScratch.Tool.txt
@@ -9,7 +9,7 @@ Batch.Run
 |> ORP.Compile ORS.Mod ORB.Mod ORG.Mod ~
 |> Batch.Collect |> ORP.Compile ORP.Mod ~
 |> Batch.Collect |> System.Free ORP ORG ORB ORS ~
-|> Batch.VerifyLog 90B3AE79H
+|> Batch.VerifyLog 0B2D00A5H
 |> Batch.WriteLog * 1 "*** Compiling crosscompiler ***"
 |> Batch.DeleteFiles X*.smb
 |> Batch.DeleteFiles BootLoad.smb
@@ -18,7 +18,7 @@ Batch.Run
 |> Batch.Collect |> Batch.DeleteFiles Image*.smb
 |> ORP.Compile ImageKernel.Mod/s ImageFileDir.Mod/s ImageFiles.Mod/s
         ImageTool.Mod/s ImageORL.Mod/s BootLoad.Mod/s ~
-|> Batch.Collect |> Batch.VerifyLog 0D00058FBH
+|> Batch.Collect |> Batch.VerifyLog 26F54BA0H
 |> Batch.WriteLog * 1 "*** Starting crosscompile ***"
 |> Batch.DeleteFiles *.X
 |> XORP.Compile Kernel.Mod/s FileDir.Mod/s Files.Mod/s Modules.Mod/s
@@ -28,20 +28,20 @@ Batch.Run
 |> Batch.Collect |> XORP.Compile MenuViewers.Mod/s ~
 |> Batch.Collect |> XORP.Compile TextFrames.Mod/s ~
 |> Batch.Collect |> XORP.Compile System.Mod/s ~
-|> Batch.Collect |> Batch.VerifyLog 21B7906H
+|> Batch.Collect |> Batch.VerifyLog 973E30ADH
 |> Batch.WriteLog * \ ""
 |> Batch.Collect |> XORP.Compile Edit.Mod/s ~
 |> Batch.Collect |> XORP.Compile Clipboard.Mod/s ~
 |> Batch.Collect |> XORP.Compile ORS.Mod/s ORB.Mod/s ~
 |> Batch.Collect |> XORP.Compile ORG.Mod/s ~
 |> Batch.Collect |> XORP.Compile ORP.Mod/s ~
-|> Batch.Collect |> Batch.VerifyLog 0C3451A27H
+|> Batch.Collect |> Batch.VerifyLog 54A0EDF2H
 |> Batch.WriteLog * \ ""
 |> Batch.Collect |> XORP.Compile ORTool.Mod/s ~
 |> Batch.Collect |> XORP.Compile Calc.Mod/s ResourceMonitor.Mod/s ~
 |> Batch.Collect |> XORP.Compile Graphics.Mod/s ~
 |> Batch.Collect |> XORP.Compile GraphicFrames.Mod/s ~
-|> Batch.Collect |> Batch.VerifyLog 67621921H
+|> Batch.Collect |> Batch.VerifyLog 0A40B2EDEH
 |> Batch.WriteLog * \ 2 "*** First part done - "
 |> Batch.WriteLog \ 0 "Restart Oberon and run second "
 |> Batch.WriteLog 0 "part ***"

--- a/Oberon/derive-crosscompiler.patch
+++ b/Oberon/derive-crosscompiler.patch
@@ -33,9 +33,9 @@
 --- 1/XORG.Mod.txt
 +++ 2/XORG.Mod.txt
 @@ -1,5 +1,5 @@
--MODULE ORG; (* NW  24.6.2014  code generator in Oberon-07 for RISC*)
+-MODULE ORG; (* NW  31.5.2015  code generator in Oberon-07 for RISC*)
 -  IMPORT SYSTEM, Files, ORS, ORB;
-+MODULE XORG; (* NW  24.6.2014  code generator in Oberon-07 for RISC*)
++MODULE XORG; (* NW  31.5.2015  code generator in Oberon-07 for RISC*)
 +  IMPORT SYSTEM, Files, ORS, ORB := XORB;
    (*Code generator for Oberon compiler for RISC processor.
       Procedural interface to Parser OSAP; result in array "code".


### PR DESCRIPTION
The most recent files fetched by get_files.sh contain a new ORG.Mod that
does not patch cleanly.

This script updates the patch (which really was only a change to the
comment at the top of the file), as well as the resulting checksums.